### PR TITLE
v0.1.5 - Improved use of gtfs reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/target
 *.zip
+*.pb
 crates/server/sweden
 .direnv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
  "chrono",
  "criterion",
  "csv",
+ "dashmap",
  "memmap2",
  "rayon",
  "serde",
@@ -546,6 +547,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +795,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1039,7 +1060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,6 @@ dependencies = [
  "chrono",
  "criterion",
  "csv",
- "memmap",
  "rayon",
  "serde",
  "thiserror 2.0.17",
@@ -1199,16 +1198,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "mime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "blaise"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bitvec",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
  "chrono",
  "criterion",
  "csv",
+ "memmap2",
  "rayon",
  "serde",
  "thiserror 2.0.17",
@@ -1198,6 +1199,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
  "chrono",
  "criterion",
  "csv",
+ "memmap",
  "rayon",
  "serde",
  "thiserror 2.0.17",
@@ -1200,6 +1201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "axum",
  "blaise",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
 name = "async-compression"
 version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,7 +196,11 @@ dependencies = [
  "criterion",
  "csv",
  "dashmap",
+ "gtfs-rt",
  "memmap2",
+ "prost",
+ "prost-build",
+ "prost-derive",
  "rayon",
  "serde",
  "thiserror 2.0.17",
@@ -452,7 +462,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -472,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -594,7 +604,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -625,10 +635,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -697,7 +729,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -767,6 +799,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gtfs-rt"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34af11e4d8a664910a4399b7eeb8b9e9e0b7dbf50f0667446c74a33073862d5"
+dependencies = [
+ "prost",
+ "prost-build",
+ "prost-derive",
+ "serde",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,12 +853,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1090,6 +1149,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1171,6 +1239,18 @@ checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
 dependencies = [
  "zlib-rs",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1256,6 +1336,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1349,6 +1435,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,12 +1521,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1659,6 +1819,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,7 +2005,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1961,6 +2147,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
@@ -1987,7 +2184,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2018,6 +2215,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,7 +2253,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2054,7 +2264,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2146,7 +2356,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2243,7 +2453,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2420,7 +2630,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -2476,6 +2686,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,7 +2749,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2538,7 +2760,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2838,7 +3060,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -2859,7 +3081,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2879,7 +3101,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -2900,7 +3122,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2933,7 +3155,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ blaise = { path = "." }
 bitvec = "1.0.1"
 chrono = "0.4.42"
 csv = "1.4.0"
+dashmap = "6.1.0"
 memmap2 = "0.9.9"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ blaise = { path = "." }
 bitvec = "1.0.1"
 chrono = "0.4.42"
 csv = "1.4.0"
+memmap2 = "0.9.9"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.1.4"
+version = "0.1.5"
 name = "blaise"
 description = "A fast, local-first engine for GTFS transit data. Handles routing, fuzzy search, and geospatial queries without relying on external APIs."
 authors = ["Vincent Brodin <vincent.brodin21@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,10 @@ bitvec = "1.0.1"
 chrono = "0.4.42"
 csv = "1.4.0"
 dashmap = "6.1.0"
+gtfs-rt = "0.5.0"
 memmap2 = "0.9.9"
+prost = "0.11"
+prost-derive = "0.11"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.17"
@@ -43,3 +46,7 @@ zip = "7.2.0"
 
 [dev-dependencies]
 criterion = "0.8.1"
+
+
+[build-dependencies]
+prost-build = "0.11"

--- a/benches/blaise.rs
+++ b/benches/blaise.rs
@@ -1,7 +1,7 @@
 use blaise::{
     gtfs::GtfsReader,
-    prelude::Repository,
     raptor::{Allocator, Location},
+    repository::Repository,
     shared::{Coordinate, Time},
 };
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/benches/blaise.rs
+++ b/benches/blaise.rs
@@ -43,10 +43,10 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let gtfs = GtfsReader::new()
         .from_zip_cache(gtfs_data_path)
-        .expect("Failed to load GTFS zip");
-    let repository = Repository::new()
-        .load_gtfs(gtfs)
-        .expect("Failed to build repository");
+        .expect("Failed to create GTFS reader")
+        .par_read()
+        .expect("Failed to read GTFS data");
+    let repository = Repository::new().load_gtfs(gtfs);
 
     let mut allocator = Allocator::new(&repository);
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 publish = false
 

--- a/crates/server/src/api/gtfs.rs
+++ b/crates/server/src/api/gtfs.rs
@@ -4,7 +4,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use blaise::prelude::*;
+use blaise::{gtfs::GtfsReader, repository::Repository};
 use futures_util::StreamExt;
 use reqwest::header::ACCEPT_ENCODING;
 use std::{collections::HashMap, fs, path::Path, sync::Arc, time::Instant};

--- a/crates/server/src/api/routing.rs
+++ b/crates/server/src/api/routing.rs
@@ -6,8 +6,9 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use blaise::{
-    prelude::*,
     raptor::{LegType, Location, Raptor, TimeConstraint},
+    repository::Repository,
+    shared::{Coordinate, Time},
 };
 use std::{
     collections::HashMap,

--- a/crates/server/src/api/routing.rs
+++ b/crates/server/src/api/routing.rs
@@ -22,6 +22,7 @@ pub async fn routing(
     State(state): State<Arc<AppState>>,
 ) -> Result<Response, StatusCode> {
     if let Some(repository) = &*state.repository.read().await
+        && let Some(realtime) = &*state.realtime.read().await
         && let Some(pool) = &*state.allocator_pool.read().await
     {
         let from = if let Some(from) = params.get("from") {
@@ -67,6 +68,7 @@ pub async fn routing(
             "Looking for a route from {:?} to {:?} | time constraint: {:?} | allowing walks: {} | sending shapes: {}",
             from, to, time_constrait, allow_walks, include_shapes
         );
+
         let raptor = Raptor::new(repository, from, to)
             .with_time_constraint(time_constrait)
             .allow_walks(allow_walks);
@@ -80,12 +82,22 @@ pub async fn routing(
             {
                 let from = repository.stop_by_id(from_stop).unwrap();
                 let to = repository.stop_by_id(to_stop).unwrap();
+                let mut delay = String::from("no delay");
+                if let LegType::Transit(trip_idx) = leg.leg_type
+                    && let Some(update_idx) = realtime.trip_updates[trip_idx as usize]
+                {
+                    let update = &realtime.updates[update_idx as usize];
+                    if let Some(trip_update) = &update.trip_update {
+                        delay = format!("{} delay", trip_update.delay())
+                    }
+                }
                 debug!(
-                    "{leg_type} {} -> {} @ {} -> {}",
+                    "{leg_type} {} -> {} @ {} -> {} | {}",
                     from.name,
                     to.name,
                     leg.departue_time.to_hms_string(),
-                    leg.arrival_time.to_hms_string()
+                    leg.arrival_time.to_hms_string(),
+                    delay
                 );
                 leg.stops.iter().for_each(|leg_stop| {
                     if let Location::Stop(stop_id) = &leg_stop.location {

--- a/crates/server/src/api/search.rs
+++ b/crates/server/src/api/search.rs
@@ -8,8 +8,8 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use blaise::prelude::*;
-use std::{collections::HashMap, sync::Arc};
+use blaise::shared::{AVERAGE_STOP_DISTANCE, Coordinate, Distance};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 use tracing::warn;
 
 pub async fn search_areas(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -57,12 +57,12 @@ async fn main() {
     if app_state.gtfs_data_path.exists() {
         info!("Loading data...");
         let now = Instant::now();
-        let reader = GtfsReader::new()
-            .from_zip(&app_state.gtfs_data_path)
-            .expect("Failed to build gtfs reader");
-        let repo = Repository::new()
-            .load_gtfs(reader)
-            .expect("Failed to load gtfs data in repository");
+        let data = GtfsReader::new()
+            .from_zip_cache(&app_state.gtfs_data_path)
+            .expect("Failed to build gtfs reader")
+            .par_read()
+            .expect("Failed to read gtfs data");
+        let repo = Repository::new().load_gtfs(data);
         info!("Loading data took {:?}", now.elapsed());
         info!("Allocating {alloc_count} pools...");
         let now = Instant::now();

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -4,8 +4,8 @@ mod state;
 
 use crate::state::{AllocatorPool, AppState};
 use axum::routing::get;
-use blaise::prelude::*;
-use std::{env, path::Path, sync::Arc, time::Instant};
+use blaise::{gtfs::GtfsReader, repository::Repository};
+use std::{env, path::Path, str::FromStr, sync::Arc, time::Instant};
 use tokio::{net::TcpListener, sync::RwLock};
 use tracing::{Level, info, warn};
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -55,15 +55,18 @@ async fn main() {
     };
 
     if app_state.gtfs_data_path.exists() {
-        info!("Loading data...");
-        let now = Instant::now();
+        info!("Reading GTFS data...");
+        let mut now = Instant::now();
         let data = GtfsReader::new()
             .from_zip_cache(&app_state.gtfs_data_path)
             .expect("Failed to build gtfs reader")
             .par_read()
             .expect("Failed to read gtfs data");
+        info!("Reading GTFS data took {:?}", now.elapsed());
+        info!("Loading GTFS data...");
+        now = Instant::now();
         let repo = Repository::new().load_gtfs(data);
-        info!("Loading data took {:?}", now.elapsed());
+        info!("Loading GTFS data took {:?}", now.elapsed());
         info!("Allocating {alloc_count} pools...");
         let now = Instant::now();
         let pool = AllocatorPool::new(alloc_count, &repo);

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -4,8 +4,8 @@ mod state;
 
 use crate::state::{AllocatorPool, AppState};
 use axum::routing::get;
-use blaise::{gtfs::GtfsReader, repository::Repository};
-use std::{env, path::Path, str::FromStr, sync::Arc, time::Instant};
+use blaise::{gtfs::GtfsReader, realtime::Realtime, repository::Repository};
+use std::{env, fs::File, io::Read, path::Path, str::FromStr, sync::Arc, time::Instant};
 use tokio::{net::TcpListener, sync::RwLock};
 use tracing::{Level, info, warn};
 
@@ -34,6 +34,10 @@ async fn main() {
         .map(|path_str| Path::new(&path_str).to_owned())
         .expect("Missing GTFS_DATA_PATH");
 
+    let rt_data_path = env::var("RT_DATA_PATH")
+        .map(|path_str| Path::new(&path_str).to_owned())
+        .expect("Missing RT_DATA_PATH");
+
     let alloc_count = env::var("ALLOCATOR_COUNT")
         .map(|value| {
             value
@@ -49,6 +53,7 @@ async fn main() {
     // Built app state
     let app_state = AppState {
         repository: RwLock::new(None),
+        realtime: RwLock::new(None),
         allocator_pool: RwLock::new(None),
         allocator_count: alloc_count,
         gtfs_data_path,
@@ -67,12 +72,24 @@ async fn main() {
         now = Instant::now();
         let repo = Repository::new().load_gtfs(data);
         info!("Loading GTFS data took {:?}", now.elapsed());
+        info!("Loading RT data...");
+        now = Instant::now();
+        let mut rt_file = File::open(rt_data_path).expect("Failed to open rt file");
+        let mut buf: Vec<u8> = Vec::with_capacity(1024);
+        rt_file
+            .read_to_end(&mut buf)
+            .expect("Failed to read rt file");
+        let rt = Realtime::new(&repo)
+            .load(&buf, &repo)
+            .expect("Failed to load rt file");
+        info!("Loading RT data took {:?}", now.elapsed());
         info!("Allocating {alloc_count} pools...");
         let now = Instant::now();
         let pool = AllocatorPool::new(alloc_count, &repo);
         info!("Allocating {alloc_count} pools took {:?}", now.elapsed());
         let _ = app_state.allocator_pool.write().await.replace(pool);
         let _ = app_state.repository.write().await.replace(repo);
+        let _ = app_state.realtime.write().await.replace(rt);
     } else {
         warn!("No GTFS data found.");
     }

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -1,4 +1,4 @@
-use blaise::{raptor::Allocator, repository::Repository};
+use blaise::{raptor::Allocator, realtime::Realtime, repository::Repository};
 use crossbeam_queue::ArrayQueue;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -9,6 +9,7 @@ pub struct AppState {
     pub gtfs_data_path: PathBuf,
     pub allocator_count: usize,
     pub repository: RwLock<Option<Repository>>,
+    pub realtime: RwLock<Option<Realtime>>,
     pub allocator_pool: RwLock<Option<AllocatorPool>>,
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,6 @@ VERSION=$(grep '^version =' Cargo.toml | head -1 | cut -d '"' -f 2)
 echo "Starting deployment for $PROJECT_NAME v$VERSION..."
 
 echo "📦 Publishing to Crates.io..."
-# cargo publish --allow-dirty
+cargo publish --allow-dirty
 
-./deploy_docker.sh
+./docker_deploy.sh

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           # and pkg-config is in nativeBuildInputs.
           shellHook = ''
             echo "🦀 Welcome to the Blaise development shell!"
-            alias bench = "bencher run --project blaise --adapter rust_criterion --branch v0.1.5 "cargo bench""
+            # alias bench = "bencher run --project blaise --adapter rust_criterion --branch v0.1.5 "cargo bench""
             '';
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,8 @@
           # and pkg-config is in nativeBuildInputs.
           shellHook = ''
             echo "🦀 Welcome to the Blaise development shell!"
-          '';
+            alias bench = "bencher run --project blaise --adapter rust_criterion --branch v0.1.5 "cargo bench""
+            '';
         };
       });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
             pkgs.taplo
             pkgs.nodePackages.vscode-json-languageserver
             pkgs.dockerfile-language-server
+            pkgs.protobuf
           ];
 
           # Libraries your project links to go here

--- a/src/gtfs/config.rs
+++ b/src/gtfs/config.rs
@@ -1,0 +1,44 @@
+#[derive(Debug)]
+pub struct Config {
+    pub stops_path: String,
+    pub areas_path: String,
+    pub routes_path: String,
+    pub agency_path: String,
+    pub stop_areas_path: String,
+    pub transfers_path: String,
+    pub stop_times_path: String,
+    pub trips_path: String,
+    pub shapes_path: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            stops_path: "stops.txt".into(),
+            areas_path: "areas.txt".into(),
+            routes_path: "routes.txt".into(),
+            agency_path: "agency.txt".into(),
+            stop_areas_path: "stop_areas.txt".into(),
+            transfers_path: "transfers.txt".into(),
+            stop_times_path: "stop_times.txt".into(),
+            trips_path: "trips.txt".into(),
+            shapes_path: "shapes.txt".into(),
+        }
+    }
+}
+
+impl<'a> Config {
+    pub fn to_slice(&'a self) -> [&'a str; 9] {
+        [
+            self.stops_path.as_str(),
+            self.areas_path.as_str(),
+            self.routes_path.as_str(),
+            self.stop_times_path.as_str(),
+            self.stop_areas_path.as_str(),
+            self.transfers_path.as_str(),
+            self.stops_path.as_str(),
+            self.trips_path.as_str(),
+            self.shapes_path.as_str(),
+        ]
+    }
+}

--- a/src/gtfs/data.rs
+++ b/src/gtfs/data.rs
@@ -1,0 +1,46 @@
+use crate::gtfs::{
+    GtfsArea, GtfsRoute, GtfsShape, GtfsStop, GtfsStopArea, GtfsStopTime, GtfsTransfer, GtfsTrip,
+};
+
+#[derive(Default, Debug)]
+pub struct GtfsData {
+    pub stops: Vec<GtfsStop>,
+    pub areas: Vec<GtfsArea>,
+    pub stop_areas: Vec<GtfsStopArea>,
+    pub routes: Vec<GtfsRoute>,
+    pub trips: Vec<GtfsTrip>,
+    pub transfers: Vec<GtfsTransfer>,
+    pub stop_times: Vec<GtfsStopTime>,
+    pub shapes: Vec<GtfsShape>,
+}
+
+impl From<Vec<GtfsTable>> for GtfsData {
+    fn from(value: Vec<GtfsTable>) -> Self {
+        let mut data = Self::default();
+        value.into_iter().for_each(|table| match table {
+            GtfsTable::Stops(gtfs_stops) => data.stops = gtfs_stops,
+            GtfsTable::Areas(gtfs_areas) => data.areas = gtfs_areas,
+            GtfsTable::StopAreas(gtfs_stop_areas) => data.stop_areas = gtfs_stop_areas,
+            GtfsTable::Routes(gtfs_routes) => data.routes = gtfs_routes,
+            GtfsTable::Trips(gtfs_trips) => data.trips = gtfs_trips,
+            GtfsTable::Transfers(gtfs_transfers) => data.transfers = gtfs_transfers,
+            GtfsTable::StopTimes(gtfs_stop_times) => data.stop_times = gtfs_stop_times,
+            GtfsTable::Shapes(gtfs_shapes) => data.shapes = gtfs_shapes,
+            GtfsTable::Unkown => (),
+        });
+        data
+    }
+}
+
+#[derive(Debug)]
+pub enum GtfsTable {
+    Stops(Vec<GtfsStop>),
+    Areas(Vec<GtfsArea>),
+    StopAreas(Vec<GtfsStopArea>),
+    Routes(Vec<GtfsRoute>),
+    Trips(Vec<GtfsTrip>),
+    Transfers(Vec<GtfsTransfer>),
+    StopTimes(Vec<GtfsStopTime>),
+    Shapes(Vec<GtfsShape>),
+    Unkown,
+}

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -1,7 +1,12 @@
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use memmap2::MmapOptions;
+use rayon::{
+    iter::{IntoParallelIterator, ParallelIterator},
+    slice::ParallelSlice,
+};
+use serde::de::DeserializeOwned;
 use std::{
     fs::{self, File},
-    io::{self},
+    io::{self, Read},
     path::{Path, PathBuf},
 };
 use thiserror::Error;
@@ -103,35 +108,40 @@ impl GtfsReader {
                 if !file_path.exists() {
                     return Ok(GtfsTable::Unkown);
                 }
+                if filename == config.shapes_path.as_str() {
+                    let data: Vec<GtfsShape> = GtfsReader::parse_big_file_parallel(file_path)?;
+                    return Ok(GtfsTable::Shapes(data));
+                } else if filename == config.stop_times_path.as_str() {
+                    let data: Vec<GtfsStopTime> = GtfsReader::parse_big_file_parallel(file_path)?;
+                    return Ok(GtfsTable::StopTimes(data));
+                }
+
                 let file = File::open(&file_path)?;
-                let reader = std::io::BufReader::with_capacity(128 * 1024, file);
-                let mut csv = csv::Reader::from_reader(reader);
+                let buf_reader = std::io::BufReader::with_capacity(128 * 1024, file);
+                let mut reader = csv::Reader::from_reader(buf_reader);
                 let table = if filename == config.stops_path.as_str() {
-                    let data: Vec<GtfsStop> = csv.deserialize().collect::<Result<Vec<_>, _>>()?;
+                    let data: Vec<GtfsStop> =
+                        reader.deserialize().collect::<Result<Vec<_>, _>>()?;
                     GtfsTable::Stops(data)
                 } else if filename == config.areas_path.as_str() {
-                    let data: Vec<GtfsArea> = csv.deserialize().collect::<Result<Vec<_>, _>>()?;
+                    let data: Vec<GtfsArea> =
+                        reader.deserialize().collect::<Result<Vec<_>, _>>()?;
                     GtfsTable::Areas(data)
                 } else if filename == config.stop_areas_path.as_str() {
                     let data: Vec<GtfsStopArea> =
-                        csv.deserialize().collect::<Result<Vec<_>, _>>()?;
+                        reader.deserialize().collect::<Result<Vec<_>, _>>()?;
                     GtfsTable::StopAreas(data)
                 } else if filename == config.routes_path.as_str() {
-                    let data: Vec<GtfsRoute> = csv.deserialize().collect::<Result<Vec<_>, _>>()?;
+                    let data: Vec<GtfsRoute> =
+                        reader.deserialize().collect::<Result<Vec<_>, _>>()?;
                     GtfsTable::Routes(data)
                 } else if filename == config.transfers_path.as_str() {
                     let data: Vec<GtfsTransfer> =
-                        csv.deserialize().collect::<Result<Vec<_>, _>>()?;
+                        reader.deserialize().collect::<Result<Vec<_>, _>>()?;
                     GtfsTable::Transfers(data)
-                } else if filename == config.stop_times_path.as_str() {
-                    let data: Vec<GtfsStopTime> =
-                        csv.deserialize().collect::<Result<Vec<_>, _>>()?;
-                    GtfsTable::StopTimes(data)
-                } else if filename == config.shapes_path.as_str() {
-                    let data: Vec<GtfsShape> = csv.deserialize().collect::<Result<Vec<_>, _>>()?;
-                    GtfsTable::Shapes(data)
                 } else if filename == config.trips_path.as_str() {
-                    let data: Vec<GtfsTrip> = csv.deserialize().collect::<Result<Vec<_>, _>>()?;
+                    let data: Vec<GtfsTrip> =
+                        reader.deserialize().collect::<Result<Vec<_>, _>>()?;
                     GtfsTable::Trips(data)
                 } else {
                     GtfsTable::Unkown
@@ -140,5 +150,51 @@ impl GtfsReader {
             })
             .collect::<Result<_, self::Error>>()?;
         Ok(GtfsData::from(data))
+    }
+
+    fn parse_big_file_parallel<P, T>(path: P) -> Result<Vec<T>, self::Error>
+    where
+        P: AsRef<Path>,
+        T: DeserializeOwned + Sync + Send,
+    {
+        let file = File::open(path).unwrap();
+        let mmap = unsafe { MmapOptions::new().map(&file)? };
+
+        let num_threads = rayon::current_num_threads();
+        let len = mmap.len();
+        let chunk_size = len / num_threads;
+
+        let header_len = mmap.iter().position(|&b| b == b'\n').unwrap() + 1;
+        let headers = &mmap[0..header_len];
+
+        let mut offsets = Vec::with_capacity(num_threads + 1);
+        offsets.push(header_len);
+
+        for i in 1..num_threads {
+            let mut target = i * chunk_size;
+            while target < len && mmap[target] != b'\n' {
+                target += 1;
+            }
+            offsets.push(target + 1);
+        }
+        offsets.push(len);
+
+        let chunks: Result<Vec<Vec<T>>, csv::Error> = offsets
+            .par_windows(2)
+            .map(|window| {
+                let start = window[0];
+                let end = window[1];
+                let slice = &mmap[start..end];
+                let chain = headers.chain(slice);
+                let mut csv = csv::ReaderBuilder::new()
+                    .has_headers(true)
+                    .from_reader(chain);
+
+                csv.deserialize().collect::<Result<Vec<T>, csv::Error>>()
+            })
+            .collect();
+
+        let data: Result<Vec<T>, csv::Error> = chunks.map(|c| c.into_iter().flatten().collect());
+        Ok(data?)
     }
 }

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -1,6 +1,4 @@
-use memmap::Mmap;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use serde::de::DeserializeOwned;
 use std::{
     fs::{self, File},
     io::{self},

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -1,3 +1,4 @@
+use memmap::Mmap;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::de::DeserializeOwned;
 use std::{
@@ -7,7 +8,6 @@ use std::{
 };
 use thiserror::Error;
 use tracing::info;
-use zip::{ZipArchive, read::ZipFile};
 
 mod config;
 mod data;
@@ -32,17 +32,9 @@ pub enum Error {
 }
 
 #[derive(Default, Debug)]
-pub enum Source {
-    #[default]
-    None,
-    Zip(ZipArchive<File>),
-    Directory(PathBuf),
-}
-
-#[derive(Default, Debug)]
 pub struct GtfsReader {
     config: Config,
-    storage: Source,
+    dir_path: PathBuf,
 }
 
 impl GtfsReader {
@@ -56,20 +48,19 @@ impl GtfsReader {
     }
 
     pub fn from_zip<P: AsRef<Path>>(mut self, path: P) -> Result<Self, self::Error> {
-        let zip_file = File::open(path)?;
-        let archive = ZipArchive::new(zip_file)?;
-        self.storage = Source::Zip(archive);
+        let dir_path = GtfsReader::create_cache_dir(path)?;
+        self.dir_path = dir_path;
         Ok(self)
     }
 
     pub fn from_zip_cache<P: AsRef<Path>>(mut self, path: P) -> Result<Self, self::Error> {
-        let directory = GtfsReader::get_or_create_cache_dir(&path)?;
-        self.storage = Source::Directory(directory);
+        let dir_path = GtfsReader::get_or_create_cache_dir(&path)?;
+        self.dir_path = dir_path;
         Ok(self)
     }
 
     pub fn from_directory<P: AsRef<Path>>(mut self, path: P) -> Self {
-        self.storage = Source::Directory(path.as_ref().to_path_buf());
+        self.dir_path = path.as_ref().to_path_buf();
         self
     }
 
@@ -80,12 +71,7 @@ impl GtfsReader {
         target_dir.set_extension("");
 
         if !target_dir.exists() {
-            info!("Extracting GTFS to {:?}...", target_dir);
-            fs::create_dir_all(&target_dir)?;
-
-            let file = fs::File::open(zip_path)?;
-            let mut archive = zip::ZipArchive::new(file)?;
-            archive.extract(&target_dir)?;
+            target_dir = GtfsReader::create_cache_dir(zip_path)?;
         } else {
             info!("Using existing GTFS cache at {:?}", target_dir);
         }
@@ -93,20 +79,23 @@ impl GtfsReader {
         Ok(target_dir)
     }
 
+    fn create_cache_dir<P: AsRef<Path>>(zip_path: P) -> Result<PathBuf, self::Error> {
+        let zip_path = zip_path.as_ref();
+        let mut target_dir = PathBuf::from(zip_path);
+        target_dir.set_extension("");
+        info!("Extracting GTFS to {:?}...", target_dir);
+        fs::create_dir_all(&target_dir)?;
+        let file = fs::File::open(zip_path)?;
+        let mut archive = zip::ZipArchive::new(file)?;
+        archive.extract(&target_dir)?;
+        Ok(target_dir)
+    }
+
     /// Reads all the gtfs data into a `GtfsData` struct in parallel
     pub fn par_read(&self) -> Result<GtfsData, self::Error> {
         let config = &self.config;
         let file_names = config.to_slice();
-
-        let dir_path = match &self.storage {
-            Source::Directory(p) => p,
-            Source::Zip(_) => {
-                return Err(self::Error::Io(std::io::Error::other(
-                    "Parallel read requires Source::Directory (use from_zip_cache)",
-                )));
-            }
-            Source::None => return Err(self::Error::MissingSource),
-        };
+        let dir_path = &self.dir_path;
 
         let data: Vec<GtfsTable> = file_names
             .into_par_iter()
@@ -154,140 +143,4 @@ impl GtfsReader {
             .collect::<Result<_, self::Error>>()?;
         Ok(GtfsData::from(data))
     }
-
-    pub fn stream_stops<F>(&mut self, f: F) -> Result<(), self::Error>
-    where
-        F: FnMut((usize, GtfsStop)),
-    {
-        match &mut self.storage {
-            Source::None => Err(self::Error::MissingSource),
-            Source::Zip(archive) => stream_from_zip(archive, &self.config.stops_path, f),
-            Source::Directory(path) => stream_from_dir(path, &self.config.stops_path, f),
-        }
-    }
-
-    pub fn stream_areas<F>(&mut self, f: F) -> Result<(), self::Error>
-    where
-        F: FnMut((usize, GtfsArea)),
-    {
-        match &mut self.storage {
-            Source::None => Err(self::Error::MissingSource),
-            Source::Zip(archive) => stream_from_zip(archive, &self.config.areas_path, f),
-            Source::Directory(path) => stream_from_dir(path, &self.config.areas_path, f),
-        }
-    }
-
-    pub fn stream_stop_areas<F>(&mut self, f: F) -> Result<(), self::Error>
-    where
-        F: FnMut((usize, GtfsStopArea)),
-    {
-        match &mut self.storage {
-            Source::None => Err(self::Error::MissingSource),
-            Source::Zip(archive) => stream_from_zip(archive, &self.config.stop_areas_path, f),
-            Source::Directory(path) => stream_from_dir(path, &self.config.stop_areas_path, f),
-        }
-    }
-
-    pub fn stream_stop_times<F>(&mut self, f: F) -> Result<(), self::Error>
-    where
-        F: FnMut((usize, GtfsStopTime)),
-    {
-        match &mut self.storage {
-            Source::None => Err(self::Error::MissingSource),
-            Source::Zip(archive) => stream_from_zip(archive, &self.config.stop_times_path, f),
-            Source::Directory(path) => stream_from_dir(path, &self.config.stop_times_path, f),
-        }
-    }
-
-    pub fn stream_transfers<F>(&mut self, f: F) -> Result<(), self::Error>
-    where
-        F: FnMut((usize, GtfsTransfer)),
-    {
-        match &mut self.storage {
-            Source::None => Err(self::Error::MissingSource),
-            Source::Zip(archive) => stream_from_zip(archive, &self.config.transfers_path, f),
-            Source::Directory(path) => stream_from_dir(path, &self.config.transfers_path, f),
-        }
-    }
-
-    pub fn stream_routes<F>(&mut self, f: F) -> Result<(), self::Error>
-    where
-        F: FnMut((usize, GtfsRoute)),
-    {
-        match &mut self.storage {
-            Source::None => Err(self::Error::MissingSource),
-            Source::Zip(archive) => stream_from_zip(archive, &self.config.routes_path, f),
-            Source::Directory(path) => stream_from_dir(path, &self.config.routes_path, f),
-        }
-    }
-
-    pub fn stream_trips<F>(&mut self, f: F) -> Result<(), self::Error>
-    where
-        F: FnMut((usize, GtfsTrip)),
-    {
-        match &mut self.storage {
-            Source::None => Ok(()),
-            Source::Zip(archive) => stream_from_zip(archive, &self.config.trips_path, f),
-            Source::Directory(path) => stream_from_dir(path, &self.config.trips_path, f),
-        }
-    }
-
-    pub fn stream_shapes<F>(&mut self, f: F) -> Result<(), self::Error>
-    where
-        F: FnMut((usize, GtfsShape)),
-    {
-        match &mut self.storage {
-            Source::None => Ok(()),
-            Source::Zip(archive) => stream_from_zip(archive, &self.config.shapes_path, f),
-            Source::Directory(path) => stream_from_dir(path, &self.config.shapes_path, f),
-        }
-    }
-}
-
-fn stream_from_zip<T, F>(
-    archive: &mut ZipArchive<File>,
-    file_name: &str,
-    mut f: F,
-) -> Result<(), self::Error>
-where
-    T: DeserializeOwned,
-    F: FnMut((usize, T)),
-{
-    let file = get_file_from_zip(archive, file_name)?;
-    let mut reader = csv::Reader::from_reader(file);
-    for (i, result) in reader.deserialize().enumerate() {
-        let record: T = result?;
-        f((i, record));
-    }
-    Ok(())
-}
-
-fn stream_from_dir<T, F>(dir_path: &Path, file_name: &str, mut f: F) -> Result<(), self::Error>
-where
-    T: serde::de::DeserializeOwned,
-    F: FnMut((usize, T)),
-{
-    let file_path = dir_path.join(file_name);
-    let file = fs::File::open(file_path)?;
-
-    // BufReader is critical here for speed
-    let reader = std::io::BufReader::with_capacity(128 * 1024, file);
-    let mut csv_reader = csv::Reader::from_reader(reader);
-
-    for (i, result) in csv_reader.deserialize().enumerate() {
-        let record: T = result?;
-        f((i, record));
-    }
-    Ok(())
-}
-
-fn get_file_from_zip<'a>(
-    archive: &'a mut ZipArchive<File>,
-    name: &'a str,
-) -> Result<ZipFile<'a, File>, self::Error> {
-    let index = archive
-        .index_for_name(name)
-        .ok_or(self::Error::FileNotFound(name.to_string()))?;
-    let file = archive.by_index(index)?;
-    Ok(file)
 }

--- a/src/gtfs/models.rs
+++ b/src/gtfs/models.rs
@@ -139,9 +139,9 @@ impl From<GtfsStopTime> for StopTime {
             departure_time: Time::from_hms(&value.departure_time).unwrap(),
             headsign: value.stop_headsign.map(|val| val.into()),
             distance_traveled: value.shape_dist_traveled.map(Distance::from_meters),
-            pickup_type: StopAccessType::Regularly,
-            drop_off_type: StopAccessType::Regularly,
-            timepoint: Timepoint::Exact,
+            // pickup_type: StopAccessType::Regularly,
+            // drop_off_type: StopAccessType::Regularly,
+            // timepoint: Timepoint::Exact,
         }
     }
 }

--- a/src/gtfs/models.rs
+++ b/src/gtfs/models.rs
@@ -1,5 +1,5 @@
 use crate::{
-    repository::{Area, Route, Stop, StopAccessType, StopTime, Timepoint},
+    repository::{Area, Route, Stop, StopTime},
     shared::{
         geo::{Coordinate, Distance},
         time::Time,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod gtfs;
-pub mod prelude;
 pub mod raptor;
 pub mod repository;
 pub mod shared;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod gtfs;
 pub mod raptor;
+pub mod realtime;
 pub mod repository;
 pub mod shared;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,0 @@
-pub use crate::gtfs::*;
-pub use crate::repository::*;
-pub use crate::shared::*;
-pub use std::str::FromStr;

--- a/src/realtime/mod.rs
+++ b/src/realtime/mod.rs
@@ -1,0 +1,52 @@
+use gtfs_rt::{FeedEntity, FeedMessage};
+use prost::Message;
+use tracing::debug;
+
+use crate::repository::Repository;
+
+#[derive(Debug, Clone, Default)]
+pub struct Realtime {
+    pub trip_updates: Vec<Option<u32>>,
+    pub stop_updates: Vec<Option<u32>>,
+    pub updates: Vec<FeedEntity>,
+}
+
+impl Realtime {
+    pub fn new(repository: &Repository) -> Self {
+        Self {
+            trip_updates: vec![None; repository.trips.len()],
+            stop_updates: vec![None; repository.stops.len()],
+            updates: Vec::with_capacity(1024),
+        }
+    }
+
+    pub fn load(
+        mut self,
+        bytes: &[u8],
+        repository: &Repository,
+    ) -> Result<Self, prost::DecodeError> {
+        let message = FeedMessage::decode(bytes)?;
+        println!("Found {} updates", message.entity.len());
+        self.trip_updates.fill(None);
+        self.stop_updates.fill(None);
+        self.updates.clear();
+        message
+            .entity
+            .into_iter()
+            .enumerate()
+            .for_each(|(i, entity)| {
+                if let Some(trip_update) = &entity.trip_update
+                    && let Some(trip) = repository.trip_by_id(trip_update.trip.trip_id())
+                {
+                    self.trip_updates[trip.index as usize] = Some(i as u32);
+                }
+                if let Some(entity_stop) = &entity.stop
+                    && let Some(stop) = repository.stop_by_id(entity_stop.stop_id())
+                {
+                    self.stop_updates[stop.index as usize] = Some(i as u32);
+                }
+                self.updates.push(entity);
+            });
+        Ok(self)
+    }
+}

--- a/src/repository/entities.rs
+++ b/src/repository/entities.rs
@@ -129,12 +129,12 @@ pub struct StopTime {
     pub headsign: Option<Arc<str>>,
     /// Cumulative distance traveled along the trip's shape.
     pub distance_traveled: Option<Distance>,
-    /// Policy for passenger boarding (Regular, No Pickup, etc.).
-    pub pickup_type: StopAccessType,
-    /// Policy for passenger alighting.
-    pub drop_off_type: StopAccessType,
-    /// Indicates if times are exact or estimates.
-    pub timepoint: Timepoint,
+    // Policy for passenger boarding (Regular, No Pickup, etc.).
+    // pub pickup_type: StopAccessType,
+    // Policy for passenger alighting.
+    // pub drop_off_type: StopAccessType,
+    // Indicates if times are exact or estimates.
+    // pub timepoint: Timepoint,
 }
 
 /// Metadata describing a contiguous range within a global array.

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,6 +1,3 @@
-mod entities;
-pub mod source;
-
 use crate::{
     raptor::{Location, Raptor},
     shared::{
@@ -8,8 +5,12 @@ use crate::{
         geo::{AVERAGE_STOP_DISTANCE, Coordinate, Distance},
     },
 };
-pub use entities::*;
 use std::{collections::HashMap, sync::Arc};
+
+mod entities;
+pub mod source;
+
+pub use entities::*;
 
 pub type Cell = (i32, i32);
 

--- a/src/repository/source/gtfs.rs
+++ b/src/repository/source/gtfs.rs
@@ -1,7 +1,7 @@
 use crate::{
     gtfs::{
-        self, GtfsArea, GtfsData, GtfsReader, GtfsRoute, GtfsShape, GtfsStop, GtfsStopArea,
-        GtfsStopTime, GtfsTransfer, GtfsTrip,
+        GtfsArea, GtfsData, GtfsRoute, GtfsShape, GtfsStop, GtfsStopArea, GtfsStopTime,
+        GtfsTransfer, GtfsTrip,
     },
     raptor::get_departure_time,
     repository::{

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,3 @@
+# TODO
+
+- **1**: Rewrite GTFS Reader to improve performance by reading all files in paralell and then consume them after. Current implementation streams each file in sync, this makes the GTFS Reader very IO bound. In theory we should grante a 50% reduction in time since the 2 main blokcing jobs are stop_times.txt and shapes.txt, and thus reading them in parallel would half the time.


### PR DESCRIPTION
Bumped version and fixed deploy.sh

Added par_read to gtfs reader

Improved use of gtfs reader

Fixed clippy warnings

Added mmap reading for shapes and stoptimes

Made shapes and stoptimes load in par

Added smart table reading

Removed prelude

Removed flake error

Added loading and mapping of gtfs rt protobuf files